### PR TITLE
Files contents can't contain UTF-8 chars

### DIFF
--- a/lib/writeFiles.py
+++ b/lib/writeFiles.py
@@ -7,18 +7,18 @@ out = sys.argv[2]
 data = json.load(f)
 
 for key in data["files"]:
-	val = data["files"][key]
-        try:
-            os.makedirs(out + "/" + os.path.dirname(key))
-        except:
-            print "ignoring error"
+    val = data["files"][key]
+    try:
+        os.makedirs(out + "/" + os.path.dirname(key))
+    except:
+        print "ignoring error"
 
-	if type(val) == str or type(val) == unicode:
-		print "Symlinking " + out + "/" + key
-		os.symlink(val, out + "/" + key)
+    if type(val) == str or type(val) == unicode:
+        print "Symlinking " + out + "/" + key
+        os.symlink(val, out + "/" + key)
 
-        if type(val) == dict:
-                print "Creating file " + out + "/" + key
-                o = open(out + "/" + key, "w")
-                o.write(val["content"])
+    if type(val) == dict:
+        print "Creating file " + out + "/" + key
+        with open(out + "/" + key, "w") as f:
+            f.write(val["content"].encode('UTF-8'))
 


### PR DESCRIPTION
Given the following `default.nix` file, `nix-home` fails to create `.config/Code/User/settings.json` as the content defined contains UTF-8 characters (É, ô, and à in this case). 

If these characters are removed from the string, everything is fine.

**default.nix**
```
with import <nixpkgs> {};
with import <nixhome> { inherit stdenv; inherit pkgs; };
let
  
in
mkHome {
    user = "adam";
    files = {
      # Paramètres de VSCode
      ".config/Code/User/settings.json".content = ''
        // Fichier en lecture seule. Éditer plutôt ~/default.nix
        {
          // Retirer les suggestions de mise-à-jour.
          "update.channel": "none",
          "editor.renderWhitespace": "boundary"
        }
      '';
    };
}
```


**output**
```
[adam@adam-x200-nixos:~]$ nix-home
these derivations will be built:
  /nix/store/a5d643rk1fd342gncgnvc1nv3kf737hg-adam-nix-home.drv
building path(s) ‘/nix/store/sznhrvr24c5mf0ilq8dgx658r3mc5jl4-adam-nix-home’
Creating file /nix/store/sznhrvr24c5mf0ilq8dgx658r3mc5jl4-adam-nix-home/.config/Code/User/settings.json
Traceback (most recent call last):
  File "/nix/store/5qgy7y6zw1j92dkjhmw4pjhgksy8b7vs-writeFiles.py", line 23, in <module>
    o.write(val["content"])
UnicodeEncodeError: 'ascii' codec can't encode character u'\xc9' in position 29: ordinal not in range(128)

builder for ‘/nix/store/a5d643rk1fd342gncgnvc1nv3kf737hg-adam-nix-home.drv’ failed with exit code 1
error: build of ‘/nix/store/a5d643rk1fd342gncgnvc1nv3kf737hg-adam-nix-home.drv’ failed
Failed to run
```

The culprit seems to be [`lib/writeFile.py` @ line 23](https://github.com/sheenobu/nix-home/blob/0.3.2/lib/writeFiles.py#L23) where no UTF-8 encoding is done when writing the content of the string, whence the bug when the string contains some.